### PR TITLE
Enabling editing of cards by default

### DIFF
--- a/tts/structs.go
+++ b/tts/structs.go
@@ -56,7 +56,7 @@ const (
 	// DeckCustomObject represents a custom card deck.
 	DeckCustomObject ObjectType = "DeckCustom"
 	// CardObject represents a card.
-	CardObject ObjectType = "Card"
+	CardObject ObjectType = "CardCustom"
 )
 
 // DefaultTransform is the object transform data used by default in TTS.


### PR DESCRIPTION
Currently the cards created with this (awesome) tool don't support changing the image on the fly in tabletop sim. This simple patch changes that and enables users to swap card images out via the built-in TTS custom menu : https://i.imgur.com/MFDS3vQ.png