### PR TITLE
[WIP] plugins/pkm: update api from v1 to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	fyne.io/fyne/v2 v2.0.1
 	github.com/BlueMonday/go-scryfall v0.1.1-0.20200924044520-b1c60eed23b8
-	github.com/PokemonTCG/pokemon-tcg-sdk-go v0.0.0-20181002102828-dc3327e03e0d
+	github.com/PokemonTCG/pokemon-tcg-sdk-go-v2 v0.1.0 // indirect
 	github.com/antchfx/htmlquery v1.2.3
 	github.com/antchfx/xpath v1.1.11
 	github.com/disintegration/imaging v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/BlueMonday/go-scryfall v0.1.1-0.20200924044520-b1c60eed23b8/go.mod h1
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Kodeworks/golang-image-ico v0.0.0-20141118225523-73f0f4cfade9/go.mod h1:7uhhqiBaR4CpN0k9rMjOtjpcfGd6DG2m04zQxKnWQ0I=
-github.com/PokemonTCG/pokemon-tcg-sdk-go v0.0.0-20181002102828-dc3327e03e0d h1:2gmoYvadpISMNQUPgt6T+awRYSlSqCCM/VJSppHaywA=
-github.com/PokemonTCG/pokemon-tcg-sdk-go v0.0.0-20181002102828-dc3327e03e0d/go.mod h1:pEjQt2ZS8aoGcdhvUcICmq1w5j0xEhevPKvZ1v6O++s=
+github.com/PokemonTCG/pokemon-tcg-sdk-go-v2 v0.1.0 h1:VfLDrcB7d2LXs0xTW/qBjZkQlxJ8S04EmAsTI4V8R88=
+github.com/PokemonTCG/pokemon-tcg-sdk-go-v2 v0.1.0/go.mod h1:kAcPMm0IbuQMaDLtQ+aWrkeJyX8CAcR4I5AyIglC1vY=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/antchfx/htmlquery v1.2.3 h1:sP3NFDneHx2stfNXCKbhHFo8XgNjCACnU/4AO5gWz6M=
 github.com/antchfx/htmlquery v1.2.3/go.mod h1:B0ABL+F5irhhMWg54ymEZinzMSi0Kt3I2if0BLYa3V0=

--- a/plugins/pkm/api.go
+++ b/plugins/pkm/api.go
@@ -1,9 +1,11 @@
 package pkm
 
 import (
+	"fmt"
 	"time"
 
-	pokemontcgsdk "github.com/PokemonTCG/pokemon-tcg-sdk-go/src"
+	pokemontcgsdk "github.com/PokemonTCG/pokemon-tcg-sdk-go-v2/pkg"
+	"github.com/PokemonTCG/pokemon-tcg-sdk-go-v2/pkg/request"
 )
 
 // See https://docs.pokemontcg.io/#documentationrate_limits
@@ -11,13 +13,36 @@ var rateLimiter = time.NewTicker(1.4 * 1000 * time.Millisecond)
 
 func getCards(name string, setCode string) ([]pokemontcgsdk.PokemonCard, error) {
 	<-rateLimiter.C
-	return pokemontcgsdk.GetCards(map[string]string{
-		"name":    name,
-		"setCode": setCode,
-	})
+	
+	name_query := fmt.Sprintf("name:%s", name)
+	set_query := fmt.Sprintf("set.id:%s", setCode)
+	tcg := pokemontcgsdk.NewClient("")
+	
+	cards, err := tcg.GetCards(
+		request.Query(name_query, set_query),
+		request.PageSize(5),
+	)
+
+	deref := []pokemontcgsdk.PokemonCard{}
+
+	for _, card := range cards {
+		deref = append(deref, *card)
+	}
+	
+	return deref, err
 }
 
 func getSets() ([]pokemontcgsdk.Set, error) {
 	<-rateLimiter.C
-	return pokemontcgsdk.GetSets(nil)
+	tcg := pokemontcgsdk.NewClient("")
+	
+	sets, err := tcg.GetSets(
+		request.PageSize(200),
+	)
+	deref := []pokemontcgsdk.Set{}
+
+	for _, set := range sets {
+		deref = append(deref, *set)
+	}
+	return deref, err
 }

--- a/plugins/pkm/parser.go
+++ b/plugins/pkm/parser.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	pokemontcgsdk "github.com/PokemonTCG/pokemon-tcg-sdk-go/src"
+	pokemontcgsdk "github.com/PokemonTCG/pokemon-tcg-sdk-go-v2/pkg"
 
 	"github.com/jeandeaual/tts-deckconverter/log"
 	"github.com/jeandeaual/tts-deckconverter/plugins"
@@ -155,7 +155,7 @@ func cardNamesToDeck(cards *CardNames, name string, options map[string]interface
 		deck.Cards = append(deck.Cards, plugins.CardInfo{
 			Name:        card.Name,
 			Description: buildCardDescription(card),
-			ImageURL:    card.ImageURLHiRes,
+			ImageURL:    card.Images.Large,
 			Count:       count,
 		})
 	}

--- a/plugins/pkm/set_code.go
+++ b/plugins/pkm/set_code.go
@@ -53,8 +53,8 @@ func setUp() bool {
 	standardSetToPTCGOSetMap = newSetMap()
 
 	for _, set := range sets {
-		ptcgoSetToStandardSetMap.Store(set.PtcgoCode, set.Code)
-		standardSetToPTCGOSetMap.Store(set.Code, set.PtcgoCode)
+		ptcgoSetToStandardSetMap.Store(set.PtcgoCode, set.ID)
+		standardSetToPTCGOSetMap.Store(set.ID, set.PtcgoCode)
 	}
 
 	return true

--- a/plugins/pkm/util.go
+++ b/plugins/pkm/util.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	pokemontcgsdk "github.com/PokemonTCG/pokemon-tcg-sdk-go/src"
+	pokemontcgsdk "github.com/PokemonTCG/pokemon-tcg-sdk-go-v2/pkg"
 )
 
 func formatElement(element string) string {
@@ -74,18 +74,21 @@ func buildCost(cost []string) string {
 func buildCardDescription(card pokemontcgsdk.PokemonCard) string {
 	var sb strings.Builder
 
-	sb.WriteString(card.SuperType)
+	sb.WriteString(card.Supertype)
 	sb.WriteString("\n")
 
-	sb.WriteString(card.SubType)
+	for _, subtype := range card.Subtypes {
+		sb.WriteString(subtype)
+		sb.WriteString(",")
+	}
 	if len(card.EvolvesFrom) > 0 {
 		sb.WriteString(" - Evolves from ")
 		sb.WriteString(card.EvolvesFrom)
 	}
 	sb.WriteString("\n\n")
 
-	if len(card.HP) > 0 && card.HP != "None" {
-		sb.WriteString(card.HP)
+	if len(card.Hp) > 0 && card.Hp != "None" {
+		sb.WriteString(card.Hp)
 		sb.WriteString(" HP")
 		sb.WriteString("\n\n")
 	}
@@ -100,14 +103,20 @@ func buildCardDescription(card pokemontcgsdk.PokemonCard) string {
 		sb.WriteString("\n\n")
 	}
 
-	if len(card.Ability.Type) > 0 && len(card.Ability.Name) > 0 && len(card.Ability.Text) > 0 {
-		sb.WriteString(card.Ability.Type)
-		sb.WriteString(": ")
-		sb.WriteString("[b]")
-		sb.WriteString(card.Ability.Name)
-		sb.WriteString("[/b]\n")
-		sb.WriteString(card.Ability.Text)
-		sb.WriteString("\n\n")
+	for i, ability := range card.Abilities {
+		if len(ability.Type) > 0 && len(ability.Name) > 0 && len(ability.Text) > 0 {
+			sb.WriteString(ability.Type)
+			sb.WriteString(": ")
+			sb.WriteString("[b]")
+			sb.WriteString(ability.Name)
+			sb.WriteString("[/b]\n")
+			sb.WriteString(ability.Text)
+			if i < len(card.Attacks)-1 {
+				sb.WriteString("\n\n")
+			} else {
+				sb.WriteString("\n")
+			}
+		}
 	}
 
 	for i, attack := range card.Attacks {
@@ -129,12 +138,14 @@ func buildCardDescription(card pokemontcgsdk.PokemonCard) string {
 		}
 	}
 
-	for i, text := range card.Text {
+	/* Not implementend in v2 as of 6499df97
+	for i, text := range card.rules {
 		sb.WriteString(text)
-		if i < len(card.Text)-1 {
+		if i < len(card.rules)-1 {
 			sb.WriteString("\n\n")
 		}
 	}
+	*/
 
 	if len(card.Weaknesses) > 0 {
 		sb.WriteString("\n\nResistances:\n")

--- a/plugins/pkm/util_test.go
+++ b/plugins/pkm/util_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"unicode"
 
-	pokemontcgsdk "github.com/PokemonTCG/pokemon-tcg-sdk-go/src"
+	pokemontcgsdk "github.com/PokemonTCG/pokemon-tcg-sdk-go-v2/pkg"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,20 +48,22 @@ func assertNoSpaceStartEnd(t *testing.T, description string) {
 
 func TestBuildCardDescription(t *testing.T) {
 	assertNoSpaceStartEnd(t, buildCardDescription(pokemontcgsdk.PokemonCard{
-		SuperType: "Pokémon",
-		SubType:   "Basic",
-		Text:      []string{"Test"},
+		Supertype: "Pokémon",
+		Subtypes:   []string{"Basic"},
+		//Rules:      []string{"Test"},
 	}))
 	assertNoSpaceStartEnd(t, buildCardDescription(pokemontcgsdk.PokemonCard{
-		SuperType: "Pokémon",
-		SubType:   "Basic",
-		Text:      []string{"Test 1", "Test 2"},
+		Supertype: "Pokémon",
+		Subtypes:   []string{"Basic"},
+		//Rules:      []string{"Test 1", "Test 2"},
 	}))
+
+	
 	assertNoSpaceStartEnd(t, buildCardDescription(pokemontcgsdk.PokemonCard{
-		SuperType: "Pokémon",
-		SubType:   "Basic",
-		Text:      []string{"Test"},
-		Attacks: []pokemontcgsdk.Attack{
+		Supertype: "Pokémon",
+		Subtypes:   []string{"Basic"},
+		//Rules:      []string{"Test"},
+		Attacks: []struct{
 			{
 				Cost:   []string{"Psychic", "Colorless"},
 				Name:   "Test",


### PR DESCRIPTION
This is a simple update from v1 -> v2.

Regressions:
Text was renamed to Rules, but was not implemented in the go-sdk-v2 PokemonCard object. I commented it out for now, assuming a future implementation in the go-sdk-v2.

Question:
The Attack struct was removed in the v2 sdk. On line 64 of `plugins/pkm/util_test.go` I tried replacing this with `struct` and with `pokemontcgsdk.PokemonCard.Attack`. What would be the best way to change this test/access the `Attack` struct?